### PR TITLE
Minor updates and world task

### DIFF
--- a/gazebo.orogen
+++ b/gazebo.orogen
@@ -61,11 +61,13 @@ using_library "gazebo"
 #end
 
 task_context "WorldTask" do
+    needs_configuration
     attribute "name", '/std/string'
     output_port 'time', 'base/Time'
 end
 
 task_context "ModelTask" do
+    needs_configuration
     attribute "name", '/std/string'
 end
 

--- a/gazebo.orogen
+++ b/gazebo.orogen
@@ -6,6 +6,7 @@ name "gazebo"
 # header, and this header will be loaded here
 
 import_types_from "gazeboTypes.hpp"
+import_types_from "base"
 
 using_library "gazebo"
 
@@ -59,6 +60,12 @@ using_library "gazebo"
 #    periodic 0.1
 #end
 
+task_context "WorldTask" do
+    attribute "name", '/std/string'
+    output_port 'time', 'base/Time'
+end
+
 task_context "ModelTask" do
+    attribute "name", '/std/string'
 end
 

--- a/tasks/ModelTask.cpp
+++ b/tasks/ModelTask.cpp
@@ -88,17 +88,14 @@ void gazebo::ModelTask::setLinks()
 		link_port = new RTT::InputPort<base::Vector3d>((*link)->GetName());
 		ports()->addPort(*link_port);
 		link_port_list.push_back( std::make_pair(link_port,*link) );
-			
 	}
 	links.clear();
 }
 //======================================================================================
-void gazebo::ModelTask::updateModel()
+void gazebo::ModelTask::updateHook()
 {
-	// gzmsg << " ModelTask::updateModel() from model:"<< model->GetName() << std::endl;
-	
-	updateJoints();
-	updateLinks();
+    updateJoints();
+    updateLinks();
 }
 //======================================================================================
 void gazebo::ModelTask::updateJoints()

--- a/tasks/ModelTask.cpp
+++ b/tasks/ModelTask.cpp
@@ -11,13 +11,13 @@
 static const int UNDERWATER = 1;
 
 //======================================================================================
-gazebo::ModelTask::ModelTask(std::string const& name, TaskCore::TaskState initial_state)
-	: ModelTaskBase(name, initial_state),environment(0)
+gazebo::ModelTask::ModelTask(std::string const& name)
+	: ModelTaskBase(name),environment(0)
 {
 }
 //======================================================================================
-gazebo::ModelTask::ModelTask(std::string const& name, RTT::ExecutionEngine* engine, TaskCore::TaskState initial_state)
-	: ModelTaskBase(name, engine, initial_state),environment(0)
+gazebo::ModelTask::ModelTask(std::string const& name, RTT::ExecutionEngine* engine)
+	: ModelTaskBase(name, engine),environment(0)
 {
 }
 //======================================================================================

--- a/tasks/ModelTask.cpp
+++ b/tasks/ModelTask.cpp
@@ -7,6 +7,9 @@
 // add joints, position and velocity
 //======================================================================================
 #include "ModelTask.hpp"
+
+static const int UNDERWATER = 1;
+
 //======================================================================================
 gazebo::ModelTask::ModelTask(std::string const& name, TaskCore::TaskState initial_state)
 	: ModelTaskBase(name, initial_state),environment(0)

--- a/tasks/ModelTask.cpp
+++ b/tasks/ModelTask.cpp
@@ -35,6 +35,10 @@ gazebo::ModelTask::~ModelTask()
 //======================================================================================
 void gazebo::ModelTask::setGazeboModel(physics::WorldPtr _world,  physics::ModelPtr _model, int _environment)
 {
+    std::string name = "gazebo:" + _world->GetName() + ":" + _model->GetName();
+    provides()->setName(name);
+    _name.set(name);
+
 	world = _world;
 	model = _model;
 	environment = _environment;
@@ -78,8 +82,7 @@ void gazebo::ModelTask::setLinks()
 				"/" + (*link)->GetName() << std::endl;
 		
 		gzmsg << "RockBridge: create link InputPort in Rock." << std::endl;
-		link_port = new RTT::InputPort<base::Vector3d>( "link: " + world->GetName() +
-				"/" + model->GetName() + "/" + (*link)->GetName() );
+		link_port = new RTT::InputPort<base::Vector3d>((*link)->GetName());
 		ports()->addPort(*link_port);
 		link_port_list.push_back( std::make_pair(link_port,*link) );
 			

--- a/tasks/ModelTask.hpp
+++ b/tasks/ModelTask.hpp
@@ -54,7 +54,7 @@ namespace gazebo {
 		
 		public:
 			void setGazeboModel(physics::WorldPtr, physics::ModelPtr, int);	
-			void updateModel();
+			void updateHook();
 
 		    /** TaskContext constructor for ModelTask
 		     * \param name Name of the task. This name needs to be unique to make it identifiable via nameservices.

--- a/tasks/ModelTask.hpp
+++ b/tasks/ModelTask.hpp
@@ -12,18 +12,6 @@
 
 namespace gazebo {
 
-//	class ModelActivity : public RTT::extras::SlaveActivity
-//	{
-//		public:
-//			ModelActivity(RTT::base::RunnableInterface *run=0){}; 
-//			virtual ~ModelActivity(); 
-////			virtual bool execute();
-////			virtual void step();
-
-////			RTT::internal::Signal<void(void)> update_signal;
-////			RTT::Handle update_handle;
-//	};
-
     class ModelTask : public ModelTaskBase
     {
 		friend class ModelTaskBase;

--- a/tasks/ModelTask.hpp
+++ b/tasks/ModelTask.hpp
@@ -9,12 +9,6 @@
 
 #include "gazebo/ModelTaskBase.hpp"	
 #include <gazebo/physics/physics.hh>
-#include <rtt/extras/SlaveActivity.hpp>
-
-#include <rtt/internal/Signal.hpp>
-#include <rtt/Handle.hpp>
-
-#define UNDERWATER 1
 
 namespace gazebo {
 

--- a/tasks/ModelTask.hpp
+++ b/tasks/ModelTask.hpp
@@ -48,14 +48,14 @@ namespace gazebo {
 		     * \param name Name of the task. This name needs to be unique to make it identifiable via nameservices.
 		     * \param initial_state The initial TaskState of the TaskContext. Default is Stopped state.
 		     */
-		    ModelTask(std::string const& name = "gazebo::ModelTask", TaskCore::TaskState initial_state = Stopped);
+		    ModelTask(std::string const& name = "gazebo::ModelTask");
 
 		    /** TaskContext constructor for ModelTask 
 		     * \param name Name of the task. This name needs to be unique to make it identifiable for nameservices. 
 		     * \param engine The RTT Execution engine to be used for this task, which serialises the execution of all commands, programs, state machines and incoming events for a task. 
 		     * \param initial_state The initial TaskState of the TaskContext. Default is Stopped state.
 		     */
-		    ModelTask(std::string const& name, RTT::ExecutionEngine* engine, TaskCore::TaskState initial_state = Stopped);
+		    ModelTask(std::string const& name, RTT::ExecutionEngine* engine);
 
 		    /** Default deconstructor of ModelTask
 		     */

--- a/tasks/WorldTask.cpp
+++ b/tasks/WorldTask.cpp
@@ -1,0 +1,64 @@
+/* Generated from orogen/lib/orogen/templates/tasks/Task.cpp */
+
+#include "WorldTask.hpp"
+
+using namespace gazebo;
+
+WorldTask::WorldTask(std::string const& name, TaskCore::TaskState initial_state)
+    : WorldTaskBase(name, initial_state)
+{
+}
+
+WorldTask::WorldTask(std::string const& name, RTT::ExecutionEngine* engine, TaskCore::TaskState initial_state)
+    : WorldTaskBase(name, engine, initial_state)
+{
+}
+
+WorldTask::~WorldTask()
+{
+}
+
+
+void WorldTask::setGazeboWorld(physics::WorldPtr _world)
+{
+    provides()->setName("gazebo:" + _world->GetName());
+    _name.set(_world->GetName());
+    world = _world;
+}
+
+/// The following lines are template definitions for the various state machine
+// hooks defined by Orocos::RTT. See WorldTask.hpp for more detailed
+// documentation about them.
+
+bool WorldTask::configureHook()
+{
+    if (! WorldTaskBase::configureHook())
+        return false;
+    return true;
+}
+bool WorldTask::startHook()
+{
+    if (! WorldTaskBase::startHook())
+        return false;
+    return true;
+}
+void WorldTask::updateHook()
+{
+    common::Time sim_time = world->GetSimTime();
+    _time.write(
+            base::Time::fromSeconds(sim_time.sec) +
+            base::Time::fromMicroseconds(sim_time.nsec / 1000));
+    WorldTaskBase::updateHook();
+}
+void WorldTask::errorHook()
+{
+    WorldTaskBase::errorHook();
+}
+void WorldTask::stopHook()
+{
+    WorldTaskBase::stopHook();
+}
+void WorldTask::cleanupHook()
+{
+    WorldTaskBase::cleanupHook();
+}

--- a/tasks/WorldTask.cpp
+++ b/tasks/WorldTask.cpp
@@ -4,13 +4,13 @@
 
 using namespace gazebo;
 
-WorldTask::WorldTask(std::string const& name, TaskCore::TaskState initial_state)
-    : WorldTaskBase(name, initial_state)
+WorldTask::WorldTask(std::string const& name)
+    : WorldTaskBase(name)
 {
 }
 
-WorldTask::WorldTask(std::string const& name, RTT::ExecutionEngine* engine, TaskCore::TaskState initial_state)
-    : WorldTaskBase(name, engine, initial_state)
+WorldTask::WorldTask(std::string const& name, RTT::ExecutionEngine* engine)
+    : WorldTaskBase(name, engine)
 {
 }
 

--- a/tasks/WorldTask.hpp
+++ b/tasks/WorldTask.hpp
@@ -35,14 +35,14 @@ namespace gazebo {
          * \param name Name of the task. This name needs to be unique to make it identifiable via nameservices.
          * \param initial_state The initial TaskState of the TaskContext. Default is Stopped state.
          */
-        WorldTask(std::string const& name = "gazebo::WorldTask", TaskCore::TaskState initial_state = Stopped);
+        WorldTask(std::string const& name = "gazebo::WorldTask");
 
         /** TaskContext constructor for WorldTask 
          * \param name Name of the task. This name needs to be unique to make it identifiable for nameservices. 
          * \param engine The RTT Execution engine to be used for this task, which serialises the execution of all commands, programs, state machines and incoming events for a task. 
          * \param initial_state The initial TaskState of the TaskContext. Default is Stopped state.
          */
-        WorldTask(std::string const& name, RTT::ExecutionEngine* engine, TaskCore::TaskState initial_state = Stopped);
+        WorldTask(std::string const& name, RTT::ExecutionEngine* engine);
 
         /** Default deconstructor of WorldTask
          */

--- a/tasks/WorldTask.hpp
+++ b/tasks/WorldTask.hpp
@@ -1,0 +1,112 @@
+/* Generated from orogen/lib/orogen/templates/tasks/Task.hpp */
+
+#ifndef GAZEBO_WORLDTASK_TASK_HPP
+#define GAZEBO_WORLDTASK_TASK_HPP
+
+#include "gazebo/WorldTaskBase.hpp"
+#include <gazebo/physics/physics.hh>
+
+namespace gazebo {
+
+    /*! \class WorldTask 
+     * \brief The task context provides and requires services. It uses an ExecutionEngine to perform its functions.
+     * Essential interfaces are operations, data flow ports and properties. These interfaces have been defined using the oroGen specification.
+     * In order to modify the interfaces you should (re)use oroGen and rely on the associated workflow.
+     * 
+     * \details
+     * The name of a TaskContext is primarily defined via:
+     \verbatim
+     deployment 'deployment_name'
+         task('custom_task_name','gazebo::WorldTask')
+     end
+     \endverbatim
+     *  It can be dynamically adapted when the deployment is called with a prefix argument. 
+     */
+    class WorldTask : public WorldTaskBase
+    {
+	friend class WorldTaskBase;
+
+        physics::WorldPtr world;
+
+    public:
+        void setGazeboWorld(physics::WorldPtr world);
+
+        /** TaskContext constructor for WorldTask
+         * \param name Name of the task. This name needs to be unique to make it identifiable via nameservices.
+         * \param initial_state The initial TaskState of the TaskContext. Default is Stopped state.
+         */
+        WorldTask(std::string const& name = "gazebo::WorldTask", TaskCore::TaskState initial_state = Stopped);
+
+        /** TaskContext constructor for WorldTask 
+         * \param name Name of the task. This name needs to be unique to make it identifiable for nameservices. 
+         * \param engine The RTT Execution engine to be used for this task, which serialises the execution of all commands, programs, state machines and incoming events for a task. 
+         * \param initial_state The initial TaskState of the TaskContext. Default is Stopped state.
+         */
+        WorldTask(std::string const& name, RTT::ExecutionEngine* engine, TaskCore::TaskState initial_state = Stopped);
+
+        /** Default deconstructor of WorldTask
+         */
+	~WorldTask();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from PreOperational to Stopped. If it returns false, then the
+         * component will stay in PreOperational. Otherwise, it goes into
+         * Stopped.
+         *
+         * It is meaningful only if the #needs_configuration has been specified
+         * in the task context definition with (for example):
+         \verbatim
+         task_context "TaskName" do
+           needs_configuration
+           ...
+         end
+         \endverbatim
+         */
+        bool configureHook();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from Stopped to Running. If it returns false, then the component will
+         * stay in Stopped. Otherwise, it goes into Running and updateHook()
+         * will be called.
+         */
+        bool startHook();
+
+        /** This hook is called by Orocos when the component is in the Running
+         * state, at each activity step. Here, the activity gives the "ticks"
+         * when the hook should be called.
+         *
+         * The error(), exception() and fatal() calls, when called in this hook,
+         * allow to get into the associated RunTimeError, Exception and
+         * FatalError states. 
+         *
+         * In the first case, updateHook() is still called, and recover() allows
+         * you to go back into the Running state.  In the second case, the
+         * errorHook() will be called instead of updateHook(). In Exception, the
+         * component is stopped and recover() needs to be called before starting
+         * it again. Finally, FatalError cannot be recovered.
+         */
+        void updateHook();
+
+        /** This hook is called by Orocos when the component is in the
+         * RunTimeError state, at each activity step. See the discussion in
+         * updateHook() about triggering options.
+         *
+         * Call recover() to go back in the Runtime state.
+         */
+        void errorHook();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from Running to Stopped after stop() has been called.
+         */
+        void stopHook();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from Stopped to PreOperational, requiring the call to configureHook()
+         * before calling start() again.
+         */
+        void cleanupHook();
+    };
+}
+
+#endif
+


### PR DESCRIPTION
This does a few minor updates to ModelTask and creates WorldTask.

One not-so-trivial addition is the use of updateHook for ModelTask (instead of the custom updateModel),
as the rock bridge now uses a proper activity to trigger the task.

Corresponding PR on the rock bridge: Brazilian-Institute-of-Robotics/simulation-gazebo_plugins#2
