### PR TITLE
Export the model pose, and some cleanup

### DIFF
--- a/rock_gazebo.orogen
+++ b/rock_gazebo.orogen
@@ -23,9 +23,11 @@ task_context "ModelTask" do
     # The model full name
     attribute "name", '/std/string'
 
-    # The frame name for the model pose
+    # The frame name for the model pose. It will, by default, be set to the
+    # model's full name (e.g. underwater::flat_fish)
     property 'model_frame', '/std/string'
-    # The frame name for the world
+    # The frame name for the model pose. It will, by default, be set to the
+    # world's full name (e.g. underwater)
     property 'world_frame', '/std/string'
     # The pose of the model w.r.t. the world frame
     output_port 'pose_samples', '/base/samples/RigidBodyState'

--- a/rock_gazebo.orogen
+++ b/rock_gazebo.orogen
@@ -23,7 +23,15 @@ task_context "ModelTask" do
     # The model full name
     attribute "name", '/std/string'
 
+    # The frame name for the model pose
+    property 'model_frame', '/std/string'
+    # The frame name for the world
+    property 'world_frame', '/std/string'
+    # The pose of the model w.r.t. the world frame
+    output_port 'pose_samples', '/base/samples/RigidBodyState'
+
     property "exported_links", "std/vector<rock_gazebo/LinkExport>"
+
 
     # Joints input/output ports
     input_port "joints_cmd", "/base/samples/Joints"

--- a/rock_gazebo.orogen
+++ b/rock_gazebo.orogen
@@ -24,7 +24,7 @@ task_context "ModelTask" do
     attribute "name", '/std/string'
 
     # The frame name for the model pose. It will, by default, be set to the
-    # model's full name (e.g. underwater::flat_fish)
+    # model's name (e.g. flat_fish)
     property 'model_frame', '/std/string'
     # The frame name for the model pose. It will, by default, be set to the
     # world's full name (e.g. underwater)

--- a/rock_gazeboTypes.hpp
+++ b/rock_gazeboTypes.hpp
@@ -6,6 +6,8 @@
 namespace rock_gazebo
 {
     struct LinkExport {
+        // The port name
+        std::string port_name;
         // The RBS sourceFrame, leave empty to use source_link
         std::string source_frame;
         // The RBS targetFrame, leave empty to use target_link

--- a/tasks/ModelTask.cpp
+++ b/tasks/ModelTask.cpp
@@ -35,6 +35,11 @@ void ModelTask::setGazeboModel(WorldPtr _world,  ModelPtr _model)
 
     world = _world;
     model = _model;
+
+    if (_model_frame.get().empty())
+        _model_frame.set(_model->GetName());
+    if (_world_frame.get().empty())
+        _world_frame.set(_world->GetName());
 } 
 
 void ModelTask::setupJoints()

--- a/tasks/ModelTask.cpp
+++ b/tasks/ModelTask.cpp
@@ -194,7 +194,6 @@ bool ModelTask::configureHook()
     if( (!world) && (!model) )
         return false;
 
-    gazebo_links = model->GetLinks();
     gazebo_joints = model->GetJoints();
     setupLinks();
     setupJoints();

--- a/tasks/ModelTask.cpp
+++ b/tasks/ModelTask.cpp
@@ -40,7 +40,6 @@ void ModelTask::setGazeboModel(WorldPtr _world,  ModelPtr _model)
 void ModelTask::setupJoints()
 {
     // Get all joints from a model and set Rock Input/Output Ports
-    gazebo_joints = model->GetJoints();
     for(Joint_V::iterator joint = gazebo_joints.begin(); joint != gazebo_joints.end(); ++joint)
     {
         gzmsg << "ModelTask: found joint: " << world->GetName() + "/" + model->GetName() +
@@ -153,6 +152,8 @@ bool ModelTask::configureHook()
     if( (!world) && (!model) )
         return false;
 
+    gazebo_links = model->GetLinks();
+    gazebo_joints = model->GetJoints();
     setupLinks();
     setupJoints();
 

--- a/tasks/ModelTask.cpp
+++ b/tasks/ModelTask.cpp
@@ -95,8 +95,24 @@ void ModelTask::setupLinks()
 
 void ModelTask::updateHook()
 {
+    updateModelPose();
     updateJoints();
     updateLinks();
+}
+
+void ModelTask::updateModelPose()
+{
+    math::Pose model2world = model->GetWorldPose();
+
+    RigidBodyState rbs;
+    rbs.invalidate();
+    rbs.sourceFrame = _model_frame.get();
+    rbs.targetFrame = _world_frame.get();
+    rbs.position = base::Vector3d(
+        model2world.pos.x,model2world.pos.y,model2world.pos.z);
+    rbs.orientation = base::Quaterniond(
+        model2world.rot.w,model2world.rot.x,model2world.rot.y,model2world.rot.z );
+    _pose_samples.write(rbs);
 }
 
 void ModelTask::updateJoints()

--- a/tasks/ModelTask.cpp
+++ b/tasks/ModelTask.cpp
@@ -11,13 +11,12 @@ using namespace gazebo;
 using namespace rock_gazebo;
 using namespace std;
 
-
-ModelTask::ModelTask(std::string const& name)
+ModelTask::ModelTask(string const& name)
 	: ModelTaskBase(name)
 {
 }
 
-ModelTask::ModelTask(std::string const& name, RTT::ExecutionEngine* engine)
+ModelTask::ModelTask(string const& name, RTT::ExecutionEngine* engine)
 	: ModelTaskBase(name, engine)
 {
 }
@@ -30,7 +29,7 @@ ModelTask::~ModelTask()
 
 void ModelTask::setGazeboModel(WorldPtr _world,  ModelPtr _model)
 {
-    std::string name = "gazebo:" + _world->GetName() + ":" + _model->GetName();
+    string name = "gazebo:" + _world->GetName() + ":" + _model->GetName();
     provides()->setName(name);
     _name.set(name);
 
@@ -45,7 +44,7 @@ void ModelTask::setupJoints()
     for(Joint_V::iterator joint = gazebo_joints.begin(); joint != gazebo_joints.end(); ++joint)
     {
         gzmsg << "ModelTask: found joint: " << world->GetName() + "/" + model->GetName() +
-                "/" + (*joint)->GetName() << std::endl;
+                "/" + (*joint)->GetName() << endl;
 
         joints_in.names.push_back( (*joint)->GetName() );
         joints_in.elements.push_back( base::JointState::Effort(0.0) );
@@ -105,8 +104,8 @@ void ModelTask::updateJoints()
 {
     _joints_cmd.readNewest( joints_in );
 
-    std::vector<std::string> names;
-    std::vector<double> positions;
+    vector<string> names;
+    vector<double> positions;
 
     for(Joint_V::iterator it = gazebo_joints.begin(); it != gazebo_joints.end(); ++it )
     {
@@ -160,16 +159,16 @@ bool ModelTask::configureHook()
     return true;
 }
 
-std::string ModelTask::checkExportedLinkElements(std::string element_name, std::string test, std::string option)
+string ModelTask::checkExportedLinkElements(string element_name, string test, string option)
 {
     // when not defined, source_link and target_link will recieve "world".
     // when not defined, source_frame and target_frame will receive source_link and target_link content
     if( test.empty() )
     {
-        gzmsg << "ModelTask: " << model->GetName() << " " << element_name << " not defined, using "<< option << std::endl;
+        gzmsg << "ModelTask: " << model->GetName() << " " << element_name << " not defined, using "<< option << endl;
         return option;
     }else {
-        gzmsg << "ModelTask: " << model->GetName() << " " << element_name << ": " << test << std::endl;
+        gzmsg << "ModelTask: " << model->GetName() << " " << element_name << ": " << test << endl;
         return test;
     }
 }

--- a/tasks/ModelTask.cpp
+++ b/tasks/ModelTask.cpp
@@ -197,6 +197,15 @@ bool ModelTask::configureHook()
     return true;
 }
 
+void ModelTask::cleanupHook()
+{
+    ModelTaskBase::cleanupHook();
+
+    for(ExportedLinks::iterator it = exported_links.begin(); it != exported_links.end(); ++it)
+        delete it->port;
+    exported_links.clear();
+}
+
 string ModelTask::checkExportedLinkElements(string element_name, string test, string option)
 {
     // when not defined, source_link and target_link will recieve "world".

--- a/tasks/ModelTask.cpp
+++ b/tasks/ModelTask.cpp
@@ -6,6 +6,7 @@
 //====================================================================================== 
 
 #include "ModelTask.hpp"
+#include <gazebo/common/Exception.hh>
 
 using namespace gazebo;
 using namespace rock_gazebo;
@@ -77,30 +78,16 @@ void ModelTask::setupLinks()
         exported_link.target_link_ptr = model->GetLink( it->target_link );
 
         if (it->source_link != "world" && !exported_link.source_link_ptr)
-        {
-            gzmsg << "ModelTask: cannot find link " << it->source_link << " in model" << endl;
-            gzmsg << "Exiting simulation." << endl;
-        }
+        { gzthrow("ModelTask: cannot find exported source link " << it->source_link << " in model"); }
         else if (it->target_link != "world" && !exported_link.target_link_ptr)
-        {
-            gzmsg << "ModelTask: cannot find link " << it->target_link << " in model" << endl;
-            gzmsg << "Exiting simulation." << endl;
-        }
+        { gzthrow("ModelTask: cannot find exported target link " << it->target_link << " in model"); }
         else if (it->port_name.empty())
-        {
-            gzmsg << "ModelTask: no port name given" << endl;
-            gzmsg << "Exiting simulation." << endl;
-        }
+        { gzthrow("ModelTask: no port name given in link export"); }
         else if (ports()->getPort(it->port_name))
-        {
-            gzmsg << "ModelTask: provided port name " << it->port_name << " already in use on this component" << endl;
-            gzmsg << "Exiting simulation." << endl;
-        }
+        { gzthrow("ModelTask: provided port name " << it->port_name << " already used on the task interface"); }
         else if (port_names.count(it->port_name) != 0)
-        {
-            gzmsg << "ModelTask: duplicate port name " << it->port_name << " in exported links" << endl;
-            gzmsg << "Exiting simulation." << endl;
-        }
+        { gzthrow("ModelTask: provided port name " << it->port_name << " already used by another exported link"); }
+
         port_names.insert(it->port_name);
         exported_links.push_back(exported_link);
     }

--- a/tasks/ModelTask.hpp
+++ b/tasks/ModelTask.hpp
@@ -36,12 +36,22 @@ namespace rock_gazebo {
 
             typedef base::samples::RigidBodyState RigidBodyState;
             typedef RTT::OutputPort<RigidBodyState> RBSOutPort;
-            typedef std::vector< std::pair<LinkExport,RBSOutPort*> > LinkPort;
-            LinkPort link_port;
+
+            struct ExportedLink : public LinkExport
+            {
+                LinkPtr source_link_ptr;
+                LinkPtr target_link_ptr;
+                RBSOutPort* port;
+
+                ExportedLink()
+                    : port(NULL) { }
+            };
+            typedef std::vector<ExportedLink> ExportedLinks;
+            ExportedLinks exported_links;
+
             void setupLinks();
             void updateLinks();
 
-            std::vector<LinkExport> exported_links_list;
             std::string checkExportedLinkElements(std::string, std::string, std::string);
 
         protected:

--- a/tasks/ModelTask.hpp
+++ b/tasks/ModelTask.hpp
@@ -51,6 +51,7 @@ namespace rock_gazebo {
 
             void setupLinks();
             void updateLinks();
+            void updateModelPose();
 
             std::string checkExportedLinkElements(std::string, std::string, std::string);
 

--- a/tasks/ModelTask.hpp
+++ b/tasks/ModelTask.hpp
@@ -28,7 +28,6 @@ namespace rock_gazebo {
             sdf::ElementPtr sdf;
 
             Joint_V gazebo_joints;
-            Link_V gazebo_links;
 
             base::samples::Joints joints_in;
             void setupJoints();

--- a/tasks/ModelTask.hpp
+++ b/tasks/ModelTask.hpp
@@ -62,6 +62,7 @@ namespace rock_gazebo {
 
             void updateHook();
             bool configureHook();
+            void cleanupHook();
 
 		    /** TaskContext constructor for ModelTask
 		     * \param name Name of the task. This name needs to be unique to make it identifiable via nameservices.


### PR DESCRIPTION
The main functionality change with this PR is the addition of a pose_samples port which exports the model's pose. By opposition of having to pick a link (which requires knowledge about the model's structure), the model pose is really based the model's root frame which does not depend on the model's composition.
