### PR TITLE
thrusters: set the task's name based on the plugin's name

### DIFF
--- a/tasks/ThrusterTask.cpp
+++ b/tasks/ThrusterTask.cpp
@@ -91,10 +91,10 @@ void ThrusterTask::cleanupHook()
     node->Fini();
 }
 
-void ThrusterTask::setGazeboModel(WorldPtr _world,  ModelPtr _model)
+void ThrusterTask::setGazeboModel(WorldPtr _world,  ModelPtr _model, sdf::ElementPtr _plugin)
 {
     string name = "gazebo:" + _world->GetName() + ":" + _model->GetName() +
-            ":thruster_task";
+            ":" + _plugin->Get<std::string>("name");
     provides()->setName(name);
     _name.set(name);
 

--- a/tasks/ThrusterTask.hpp
+++ b/tasks/ThrusterTask.hpp
@@ -19,7 +19,7 @@ namespace rock_gazebo {
 
         ThrusterTask(std::string const& name = "rock_gazebo::ThrusterTask");
         ThrusterTask(std::string const& name, RTT::ExecutionEngine* engine);
-	    ~ThrusterTask();
+        ~ThrusterTask();
 
         bool configureHook();
         bool startHook();
@@ -28,7 +28,7 @@ namespace rock_gazebo {
         void stopHook();
         void cleanupHook();
 
-        void setGazeboModel(WorldPtr, ModelPtr);
+        void setGazeboModel(WorldPtr, ModelPtr, sdf::ElementPtr);
 
     private:
         ModelPtr model;


### PR DESCRIPTION
This removes the arbitrary naming of the task.

Must be merged at the same time than Brazilian-Institute-of-Robotics/simulation-rock_gazebo#12
