### PR TITLE
add support to use either the wall-clock or sim-clock time in exported samples

### DIFF
--- a/rock_gazebo.orogen
+++ b/rock_gazebo.orogen
@@ -16,9 +16,17 @@ task_context "WorldTask" do
     output_port 'time', 'base/Time'
 end
 
+task_context "BaseTask" do
+    # Controls whether the components should use the simulation time (the
+    # default) or wall-clock time
+    property "use_sim_time", "/bool", true
+end
+
 # Representation of a gazebo Model object
 task_context "ModelTask" do
     needs_configuration
+
+    subclasses 'BaseTask'
 
     # The model full name
     attribute "name", '/std/string'
@@ -42,6 +50,8 @@ end
 
 task_context "ThrusterTask" do
     needs_configuration
+
+    subclasses 'BaseTask'
 
     exception_states 'NO_TOPIC_CONNECTION'
 

--- a/tasks/BaseTask.cpp
+++ b/tasks/BaseTask.cpp
@@ -1,0 +1,73 @@
+/* Generated from orogen/lib/orogen/templates/tasks/Task.cpp */
+
+#include "BaseTask.hpp"
+
+using namespace rock_gazebo;
+
+BaseTask::BaseTask(std::string const& name, TaskCore::TaskState initial_state)
+    : BaseTaskBase(name, initial_state)
+{
+}
+
+BaseTask::BaseTask(std::string const& name, RTT::ExecutionEngine* engine, TaskCore::TaskState initial_state)
+    : BaseTaskBase(name, engine, initial_state)
+{
+}
+
+BaseTask::~BaseTask()
+{
+}
+
+void BaseTask::setGazeboWorld(WorldPtr _world)
+{
+    world = _world;
+}
+
+base::Time BaseTask::getSimTime() const
+{
+    gazebo::common::Time sim_time = world->GetSimTime();
+    return base::Time::fromSeconds(sim_time.sec) +
+        base::Time::fromMicroseconds(sim_time.nsec / 1000);
+}
+
+base::Time BaseTask::getCurrentTime() const
+{
+    if (_use_sim_time)
+        return getSimTime();
+    else
+        return base::Time::now();
+}
+
+
+/// The following lines are template definitions for the various state machine
+// hooks defined by Orocos::RTT. See BaseTask.hpp for more detailed
+// documentation about them.
+
+bool BaseTask::configureHook()
+{
+    if (! BaseTaskBase::configureHook())
+        return false;
+    return true;
+}
+bool BaseTask::startHook()
+{
+    if (! BaseTaskBase::startHook())
+        return false;
+    return true;
+}
+void BaseTask::updateHook()
+{
+    BaseTaskBase::updateHook();
+}
+void BaseTask::errorHook()
+{
+    BaseTaskBase::errorHook();
+}
+void BaseTask::stopHook()
+{
+    BaseTaskBase::stopHook();
+}
+void BaseTask::cleanupHook()
+{
+    BaseTaskBase::cleanupHook();
+}

--- a/tasks/BaseTask.hpp
+++ b/tasks/BaseTask.hpp
@@ -1,0 +1,121 @@
+/* Generated from orogen/lib/orogen/templates/tasks/Task.hpp */
+
+#ifndef ROCK_GAZEBO_BASETASK_TASK_HPP
+#define ROCK_GAZEBO_BASETASK_TASK_HPP
+
+#include "rock_gazebo/BaseTaskBase.hpp"
+#include <gazebo/physics/physics.hh>
+
+namespace rock_gazebo {
+
+    /*! \class BaseTask 
+     * \brief The task context provides and requires services. It uses an ExecutionEngine to perform its functions.
+     * Essential interfaces are operations, data flow ports and properties. These interfaces have been defined using the oroGen specification.
+     * In order to modify the interfaces you should (re)use oroGen and rely on the associated workflow.
+     * 
+     * \details
+     * The name of a TaskContext is primarily defined via:
+     \verbatim
+     deployment 'deployment_name'
+         task('custom_task_name','rock_gazebo::BaseTask')
+     end
+     \endverbatim
+     *  It can be dynamically adapted when the deployment is called with a prefix argument. 
+     */
+    class BaseTask : public BaseTaskBase
+    {
+	friend class BaseTaskBase;
+
+    protected:
+        typedef gazebo::physics::WorldPtr WorldPtr;
+        WorldPtr world;
+
+    public:
+        /** Returns the simulated time */
+        base::Time getSimTime() const;
+        /** Returns either the simulated or wall-clock time, depending on the
+         * value of the use_sim_time property
+         */
+        base::Time getCurrentTime() const;
+
+        void setGazeboWorld(WorldPtr);
+
+        /** TaskContext constructor for BaseTask
+         * \param name Name of the task. This name needs to be unique to make it identifiable via nameservices.
+         * \param initial_state The initial TaskState of the TaskContext. Default is Stopped state.
+         */
+        BaseTask(std::string const& name = "rock_gazebo::BaseTask", TaskCore::TaskState initial_state = Stopped);
+
+        /** TaskContext constructor for BaseTask 
+         * \param name Name of the task. This name needs to be unique to make it identifiable for nameservices. 
+         * \param engine The RTT Execution engine to be used for this task, which serialises the execution of all commands, programs, state machines and incoming events for a task. 
+         * \param initial_state The initial TaskState of the TaskContext. Default is Stopped state.
+         */
+        BaseTask(std::string const& name, RTT::ExecutionEngine* engine, TaskCore::TaskState initial_state = Stopped);
+
+        /** Default deconstructor of BaseTask
+         */
+	~BaseTask();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from PreOperational to Stopped. If it returns false, then the
+         * component will stay in PreOperational. Otherwise, it goes into
+         * Stopped.
+         *
+         * It is meaningful only if the #needs_configuration has been specified
+         * in the task context definition with (for example):
+         \verbatim
+         task_context "TaskName" do
+           needs_configuration
+           ...
+         end
+         \endverbatim
+         */
+        bool configureHook();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from Stopped to Running. If it returns false, then the component will
+         * stay in Stopped. Otherwise, it goes into Running and updateHook()
+         * will be called.
+         */
+        bool startHook();
+
+        /** This hook is called by Orocos when the component is in the Running
+         * state, at each activity step. Here, the activity gives the "ticks"
+         * when the hook should be called.
+         *
+         * The error(), exception() and fatal() calls, when called in this hook,
+         * allow to get into the associated RunTimeError, Exception and
+         * FatalError states. 
+         *
+         * In the first case, updateHook() is still called, and recover() allows
+         * you to go back into the Running state.  In the second case, the
+         * errorHook() will be called instead of updateHook(). In Exception, the
+         * component is stopped and recover() needs to be called before starting
+         * it again. Finally, FatalError cannot be recovered.
+         */
+        void updateHook();
+
+        /** This hook is called by Orocos when the component is in the
+         * RunTimeError state, at each activity step. See the discussion in
+         * updateHook() about triggering options.
+         *
+         * Call recover() to go back in the Runtime state.
+         */
+        void errorHook();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from Running to Stopped after stop() has been called.
+         */
+        void stopHook();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from Stopped to PreOperational, requiring the call to configureHook()
+         * before calling start() again.
+         */
+        void cleanupHook();
+    };
+}
+
+#endif
+

--- a/tasks/BaseTask.hpp
+++ b/tasks/BaseTask.hpp
@@ -5,6 +5,7 @@
 
 #include "rock_gazebo/BaseTaskBase.hpp"
 #include <gazebo/physics/physics.hh>
+#include <base/Time.hpp>
 
 namespace rock_gazebo {
 

--- a/tasks/ModelTask.hpp
+++ b/tasks/ModelTask.hpp
@@ -17,21 +17,19 @@ namespace rock_gazebo {
             typedef gazebo::physics::Joint_V Joint_V;
             typedef gazebo::physics::Link_V Link_V;
             typedef gazebo::physics::ModelPtr ModelPtr;
-            typedef gazebo::physics::WorldPtr WorldPtr;
             typedef gazebo::physics::JointPtr JointPtr;
             typedef gazebo::physics::LinkPtr LinkPtr;
 	        
         friend class ModelTaskBase;
         private:
             ModelPtr model;
-            WorldPtr world;
             sdf::ElementPtr sdf;
 
             Joint_V gazebo_joints;
 
             base::samples::Joints joints_in;
             void setupJoints();
-            void updateJoints();
+            void updateJoints(base::Time const& time);
 
             typedef base::samples::RigidBodyState RigidBodyState;
             typedef RTT::OutputPort<RigidBodyState> RBSOutPort;
@@ -49,8 +47,8 @@ namespace rock_gazebo {
             ExportedLinks exported_links;
 
             void setupLinks();
-            void updateLinks();
-            void updateModelPose();
+            void updateLinks(base::Time const& time);
+            void updateModelPose(base::Time const& time);
 
             std::string checkExportedLinkElements(std::string, std::string, std::string);
 


### PR DESCRIPTION
Most of the Rock stuff is really not ready to use simulation time,
so we have to use wall-clock time for now.
