### PR TITLE
fix problems when links was exported

### DIFF
--- a/tasks/ModelTask.cpp
+++ b/tasks/ModelTask.cpp
@@ -7,7 +7,6 @@
 
 #include "ModelTask.hpp"
 #include <gazebo/common/Exception.hh>
-
 using namespace gazebo;
 using namespace rock_gazebo;
 using namespace std;
@@ -24,8 +23,7 @@ ModelTask::ModelTask(string const& name, RTT::ExecutionEngine* engine)
 
 ModelTask::~ModelTask()
 {
-    for(ExportedLinks::iterator it = exported_links.begin(); it != exported_links.end(); ++it)
-        delete it->port;
+    releaseLinks();
 }
 
 void ModelTask::setGazeboModel(WorldPtr _world,  ModelPtr _model)
@@ -58,9 +56,10 @@ void ModelTask::setupJoints()
 
 void ModelTask::setupLinks()
 {
+
     // The robot configuration YAML file must define the exported links.
     vector<LinkExport> export_conf = _exported_links.get();
-    set<string> port_names;
+
     for(vector<LinkExport>::iterator it = export_conf.begin();
             it != export_conf.end(); ++it)
     {
@@ -71,39 +70,38 @@ void ModelTask::setupLinks()
         exported_link.target_link =
             checkExportedLinkElements("target_link", it->target_link, "world");
         exported_link.source_frame =
-            checkExportedLinkElements("source_frame", it->source_frame, it->source_link);
+            checkExportedLinkElements("source_frame", it->source_frame, exported_link.source_link);
         exported_link.target_frame =
-            checkExportedLinkElements("target_frame", it->target_frame, it->target_link);
+            checkExportedLinkElements("target_frame", it->target_frame, exported_link.target_link);
+
         exported_link.source_link_ptr = model->GetLink( it->source_link );
         exported_link.target_link_ptr = model->GetLink( it->target_link );
         exported_link.port_name = it->port_name;
 
-        if (it->source_link != "world" && !exported_link.source_link_ptr)
+        if (exported_link.source_link != "world" && !exported_link.source_link_ptr)
         { gzthrow("ModelTask: cannot find exported source link " << it->source_link << " in model"); }
-        else if (it->target_link != "world" && !exported_link.target_link_ptr)
+        else if (exported_link.target_link != "world" && !exported_link.target_link_ptr)
         { gzthrow("ModelTask: cannot find exported target link " << it->target_link << " in model"); }
         else if (it->port_name.empty())
         { gzthrow("ModelTask: no port name given in link export"); }
         else if (ports()->getPort(it->port_name))
         { gzthrow("ModelTask: provided port name " << it->port_name << " already used on the task interface"); }
-        else if (port_names.count(it->port_name) != 0)
+        else if (exported_links.find(it->port_name) != exported_links.end())
         { gzthrow("ModelTask: provided port name " << it->port_name << " already used by another exported link"); }
 
-        port_names.insert(it->port_name);
-        exported_links.push_back(exported_link);
+        exported_links.insert(make_pair(it->port_name, exported_link));
     }
-
 
     for (ExportedLinks::iterator it = exported_links.begin(); it != exported_links.end(); ++it)
     {
         // Create the ports dynamicaly
         gzmsg << "ModelTask: exporting link "
-            << world->GetName() + "/" + model->GetName() + "/" + it->source_link << "2" << it->target_link
-            << " through port " << it->port_name
+            << world->GetName() + "/" + model->GetName() + "/" + it->second.source_link << "2" << it->second.target_link
+            << " through port " << it->first
             << endl;
 
-        it->port = new RBSOutPort( it->port_name );
-        ports()->addPort(*it->port);
+        it->second.port = new RBSOutPort( it->first );
+        ports()->addPort(*it->second.port);
     }
 }
 
@@ -165,22 +163,23 @@ void ModelTask::updateLinks()
     for(ExportedLinks::const_iterator it = exported_links.begin(); it != exported_links.end(); ++it)
     {
         math::Pose source_pose = math::Pose::Zero;
-        if (it->source_link_ptr)
-            source_pose = it->source_link_ptr->GetWorldPose();
+        if (it->second.source_link_ptr)
+            source_pose = it->second.source_link_ptr->GetWorldPose();
         math::Pose target_pose = math::Pose::Zero;
-        if (it->target_link_ptr)
-            target_pose = it->target_link_ptr->GetWorldPose();
+        if (it->second.target_link_ptr)
+            target_pose = it->second.target_link_ptr->GetWorldPose();
         math::Pose relative_pose( math::Pose(source_pose - target_pose) );
 
         RigidBodyState rbs;
-        rbs.sourceFrame = it->source_frame;
-        rbs.targetFrame = it->target_frame;
+        rbs.sourceFrame = it->second.source_frame;
+        rbs.targetFrame = it->second.target_frame;
         rbs.position = base::Vector3d(
             relative_pose.pos.x,relative_pose.pos.y,relative_pose.pos.z);
         rbs.orientation = base::Quaterniond(
             relative_pose.rot.w,relative_pose.rot.x,relative_pose.rot.y,relative_pose.rot.z );
 
-        it->port->write(rbs);
+        rbs.time = base::Time::now();
+        it->second.port->write(rbs);
     }
 }
 
@@ -203,9 +202,17 @@ bool ModelTask::configureHook()
 void ModelTask::cleanupHook()
 {
     ModelTaskBase::cleanupHook();
+    releaseLinks();
+}
 
-    for(ExportedLinks::iterator it = exported_links.begin(); it != exported_links.end(); ++it)
-        delete it->port;
+void ModelTask::releaseLinks()
+{
+    for(ExportedLinks::iterator it = exported_links.begin(); it != exported_links.end(); ++it) {
+        if (it->second.port != NULL) {
+            delete it->second.port;
+            it->second.port = NULL;
+        }
+    }
     exported_links.clear();
 }
 

--- a/tasks/ModelTask.hpp
+++ b/tasks/ModelTask.hpp
@@ -45,7 +45,7 @@ namespace rock_gazebo {
                 ExportedLink()
                     : port(NULL) { }
             };
-            typedef std::vector<ExportedLink> ExportedLinks;
+            typedef std::map<std::string, ExportedLink> ExportedLinks;
             ExportedLinks exported_links;
 
             void setupLinks();
@@ -54,8 +54,10 @@ namespace rock_gazebo {
 
             std::string checkExportedLinkElements(std::string, std::string, std::string);
 
+            void releaseLinks();
+
         protected:
-		
+
         public:
             void setGazeboModel(WorldPtr, ModelPtr);
 


### PR DESCRIPTION
When I was exporting more than one link, the task broke. I made some tests and I found the problem was the std::vector used to store the exported link information. I changed to std::map and I removed the std::set used to check if the port already was added.

The other problem occurs when the link names were checked. If the target_link is empty, then target_link will be "world". If the target_frame is empty, then the target_frame will be target_link. However it was passed an empty string to the target_frame when the target_link was empty. So I changed it to set the "world" value to target_frame too.
