### PR TITLE
GPS support

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -10,4 +10,5 @@
   <depend package="base/orogen/types" />
   <depend package="simulation/gazebo" />
   <depend package="simulation/gazebo_thruster" />
+  <depend package="drivers/orogen/gps_base" />
 </package>

--- a/rock_gazebo.orogen
+++ b/rock_gazebo.orogen
@@ -121,14 +121,20 @@ task_context "GPSTask" do
     # The name of the frame attached to the GPS'
     property('gps_frame', '/std/string', 'gps')
 
-    # The name of the world frame'
-    property('world_frame', '/std/string', 'nwu')
+    # The name of the reference frame for the UTM samples
+    property('utm_frame', '/std/string', 'utm')
+
+    # The name of the reference frame for the position samples
+    property('nwu_frame', '/std/string', 'nwu')
 
     # The raw GPS position
     output_port "gps_solution", "gps_base/Solution"
 
-    # Computed position in m, in the UTM coordinate provided and local to the origin
-    output_port('position_samples', '/base/samples/RigidBodyState')
+    # Computed UTM position
+    output_port 'utm_samples', '/base/samples/RigidBodyState'
+
+    # Computed position in m, in the NWU coordinate frame
+    output_port 'position_samples', '/base/samples/RigidBodyState'
 
     # UTM zone for conversion of WGS84 to UTM
     property("utm_zone", "int", 32)
@@ -137,6 +143,6 @@ task_context "GPSTask" do
     property("utm_north", "bool", true)
 
     # Origin in UTM coordinates, that is used for position readings.
-    property("origin", "/base/Position")
+    property("nwu_origin", "/base/Position")
 end
 

--- a/rock_gazebo.orogen
+++ b/rock_gazebo.orogen
@@ -1,6 +1,7 @@
 name "rock_gazebo"
 import_types_from "base"
 import_types_from "rock_gazeboTypes.hpp"
+import_types_from "gps_base"
 
 using_library "gazebo"
 using_library "gazebo_thruster"
@@ -112,5 +113,30 @@ task_context "ImuTask" do
 
     # IMU samples containing linear acceleration, orientation and angular velocity
     output_port('imu_samples', '/base/samples/IMUSensors')
+end
+
+task_context "GPSTask" do
+    subclasses 'SensorTask'
+
+    # The name of the frame attached to the GPS'
+    property('gps_frame', '/std/string', 'gps')
+
+    # The name of the world frame'
+    property('world_frame', '/std/string', 'nwu')
+
+    # The raw GPS position
+    output_port "gps_solution", "gps_base/Solution"
+
+    # Computed position in m, in the UTM coordinate provided and local to the origin
+    output_port('position_samples', '/base/samples/RigidBodyState')
+
+    # UTM zone for conversion of WGS84 to UTM
+    property("utm_zone", "int", 32)
+
+    # UTM north for conversion of WGS84 to UTM
+    property("utm_north", "bool", true)
+
+    # Origin in UTM coordinates, that is used for position readings.
+    property("origin", "/base/Position")
 end
 

--- a/rock_gazebo.orogen
+++ b/rock_gazebo.orogen
@@ -17,6 +17,8 @@ task_context "WorldTask" do
 end
 
 task_context "BaseTask" do
+    needs_configuration
+
     # Controls whether the components should use the simulation time (the
     # default) or wall-clock time
     property "use_sim_time", "/bool", true
@@ -75,8 +77,6 @@ task_context "ThrusterTask" do
 end
 
 task_context "LaserScanTask" do
-    needs_configuration
-
     subclasses 'BaseTask'
 
     # Laser line full name
@@ -87,8 +87,6 @@ task_context "LaserScanTask" do
 end
 
 task_context "CameraTask" do
-    needs_configuration
-
     subclasses 'BaseTask'
 
     # Camera full name
@@ -99,8 +97,6 @@ task_context "CameraTask" do
 end
 
 task_context "ImuTask" do
-    needs_configuration
-
     subclasses 'BaseTask'
 
     # IMU full name

--- a/rock_gazebo.orogen
+++ b/rock_gazebo.orogen
@@ -76,31 +76,30 @@ task_context "ThrusterTask" do
     output_port "joint_samples", "/base/samples/Joints"
 end
 
-task_context "LaserScanTask" do
-    subclasses 'BaseTask'
+task_context "SensorTask" do
+    subclasses "BaseTask"
+    abstract
 
-    # Laser line full name
+    # The sensor's full name
     attribute "name", "/std/string"
+end
+
+task_context "LaserScanTask" do
+    subclasses 'SensorTask'
 
     # Laser line output port
     output_port "laser_scan_samples", "/base/samples/LaserScan"
 end
 
 task_context "CameraTask" do
-    subclasses 'BaseTask'
-
-    # Camera full name
-    attribute "name", "/std/string"
+    subclasses 'SensorTask'
 
     # Camera output port
     output_port 'frame', ro_ptr('base::samples::frame::Frame')
 end
 
 task_context "ImuTask" do
-    subclasses 'BaseTask'
-
-    # IMU full name
-    attribute "name", "/std/string"
+    subclasses 'SensorTask'
 
     # The name of the frame attached to the IMU'
     property('imu_frame', '/std/string', 'imu')

--- a/tasks/BaseTask.cpp
+++ b/tasks/BaseTask.cpp
@@ -4,13 +4,13 @@
 
 using namespace rock_gazebo;
 
-BaseTask::BaseTask(std::string const& name, TaskCore::TaskState initial_state)
-    : BaseTaskBase(name, initial_state)
+BaseTask::BaseTask(std::string const& name)
+    : BaseTaskBase(name)
 {
 }
 
-BaseTask::BaseTask(std::string const& name, RTT::ExecutionEngine* engine, TaskCore::TaskState initial_state)
-    : BaseTaskBase(name, engine, initial_state)
+BaseTask::BaseTask(std::string const& name, RTT::ExecutionEngine* engine)
+    : BaseTaskBase(name, engine)
 {
 }
 

--- a/tasks/BaseTask.cpp
+++ b/tasks/BaseTask.cpp
@@ -30,6 +30,21 @@ base::Time BaseTask::getSimTime() const
         base::Time::fromMicroseconds(sim_time.nsec / 1000);
 }
 
+base::Time BaseTask::getCurrentTime(gazebo::msgs::Time sim_timestamp) const
+{
+    return getCurrentTime(base::Time::fromMicroseconds(
+                sim_timestamp.sec() * 1000000 + sim_timestamp.nsec() / 1000)
+            );
+}
+
+base::Time BaseTask::getCurrentTime(base::Time sim_timestamp) const
+{
+    if (_use_sim_time)
+        return sim_timestamp;
+    else
+        return base::Time::now() - (getSimTime() - sim_timestamp);
+}
+
 base::Time BaseTask::getCurrentTime() const
 {
     if (_use_sim_time)

--- a/tasks/BaseTask.hpp
+++ b/tasks/BaseTask.hpp
@@ -43,16 +43,14 @@ namespace rock_gazebo {
 
         /** TaskContext constructor for BaseTask
          * \param name Name of the task. This name needs to be unique to make it identifiable via nameservices.
-         * \param initial_state The initial TaskState of the TaskContext. Default is Stopped state.
          */
-        BaseTask(std::string const& name = "rock_gazebo::BaseTask", TaskCore::TaskState initial_state = Stopped);
+        BaseTask(std::string const& name = "rock_gazebo::BaseTask");
 
         /** TaskContext constructor for BaseTask 
          * \param name Name of the task. This name needs to be unique to make it identifiable for nameservices. 
          * \param engine The RTT Execution engine to be used for this task, which serialises the execution of all commands, programs, state machines and incoming events for a task. 
-         * \param initial_state The initial TaskState of the TaskContext. Default is Stopped state.
          */
-        BaseTask(std::string const& name, RTT::ExecutionEngine* engine, TaskCore::TaskState initial_state = Stopped);
+        BaseTask(std::string const& name, RTT::ExecutionEngine* engine);
 
         /** Default deconstructor of BaseTask
          */

--- a/tasks/BaseTask.hpp
+++ b/tasks/BaseTask.hpp
@@ -39,6 +39,16 @@ namespace rock_gazebo {
          */
         base::Time getCurrentTime() const;
 
+        /** @overload
+         */
+        base::Time getCurrentTime(gazebo::msgs::Time sim_timestamp) const;
+
+        /** Returns either the simulated timestamp, or a time-shifted timestamp
+         * that matches the wall-clock time, depending on the value of the
+         * use_sim_time property
+         */
+        base::Time getCurrentTime(base::Time sim_timestamp) const;
+
         void setGazeboWorld(WorldPtr);
 
         /** TaskContext constructor for BaseTask

--- a/tasks/CameraTask.cpp
+++ b/tasks/CameraTask.cpp
@@ -33,11 +33,7 @@ bool CameraTask::configureHook()
     if (! CameraTaskBase::configureHook())
         return false;
 
-    // Initialize communication node and subscribe to gazebo topic
-    node = transport::NodePtr( new transport::Node() );
-    node->Init();
-    image_subscriber = node->Subscribe("~/" + topicName, &CameraTask::readInput, this);
-    gzmsg << "CameraTask: subscribing to gazebo topic ~/" + topicName << endl;
+    topicSubscribe(&CameraTask::readInput, baseTopicName + "/image");
     return true;
 }
 bool CameraTask::startHook()
@@ -63,25 +59,10 @@ void CameraTask::errorHook()
 void CameraTask::stopHook()
 {
     CameraTaskBase::stopHook();
-    node->Fini();
 }
 void CameraTask::cleanupHook()
 {
     CameraTaskBase::cleanupHook();
-}
-
-void CameraTask::setGazeboModel( ModelPtr model, string sensorName, string topicName )
-{
-    string taskName = "gazebo:" + model->GetWorld()->GetName() + ":" + model->GetName() + ":" + sensorName;
-    if(!provides())
-        throw std::runtime_error("CameraTask::provides returned NULL");
-    provides()->setName(taskName);
-    _name.set(taskName);
-
-    BaseTask::setGazeboWorld( model->GetWorld() );
-
-    // Set topic name to communicate with Gazebo
-    this->topicName = topicName;
 }
 
 void CameraTask::readInput( ConstImageStampedPtr & imageMsg)

--- a/tasks/CameraTask.cpp
+++ b/tasks/CameraTask.cpp
@@ -46,10 +46,12 @@ bool CameraTask::startHook()
 void CameraTask::updateHook()
 {
     CameraTaskBase::updateHook();
-    if(bnew_data)
-    {
-        _frame.write(output_frame);
-        bnew_data = false;
+    { lock_guard<mutex> readGuard(readMutex);
+        if(bnew_data)
+        {
+            _frame.write(output_frame);
+            bnew_data = false;
+        }
     }
 }
 void CameraTask::errorHook()
@@ -66,18 +68,8 @@ void CameraTask::cleanupHook()
 }
 
 void CameraTask::readInput( ConstImageStampedPtr & imageMsg)
-{
+{ lock_guard<mutex> readGuard(readMutex);
     const msgs::Image &image = imageMsg->image();
-    if(!image.has_width())
-        throw std::runtime_error("rock_gazebo::CameraTask requires has_width");
-    if(!image.has_height())
-        throw std::runtime_error("rock_gazebo::CameraTask requires has_height");
-    if(!image.has_pixel_format())
-        throw std::runtime_error("rock_gazebo::CameraTask requires has_pixel_format");
-    if(!image.has_step())
-        throw std::runtime_error("rock_gazebo::CameraTask requires has_step");
-    if(!image.has_data())
-        throw std::runtime_error("rock_gazebo::CameraTask requires has_data");
 
     // Convert the image data to RGB and copy to frame struct
     common::Image img;

--- a/tasks/GPSTask.cpp
+++ b/tasks/GPSTask.cpp
@@ -1,0 +1,120 @@
+/* Generated from orogen/lib/orogen/templates/tasks/Task.cpp */
+
+#include "GPSTask.hpp"
+#include <gazebo/transport/transport.hh>
+
+using namespace std;
+using namespace rock_gazebo;
+
+GPSTask::GPSTask(std::string const& name)
+    : GPSTaskBase(name)
+    , deviationHorizontal(base::unknown<double>()), deviationVertical(base::unknown<double>())
+{
+}
+
+GPSTask::GPSTask(std::string const& name, RTT::ExecutionEngine* engine)
+    : GPSTaskBase(name, engine)
+    , deviationHorizontal(base::unknown<double>()), deviationVertical(base::unknown<double>())
+{
+}
+
+GPSTask::~GPSTask()
+{
+}
+
+
+
+/// The following lines are template definitions for the various state machine
+// hooks defined by Orocos::RTT. See GPSTask.hpp for more detailed
+// documentation about them.
+
+bool GPSTask::configureHook()
+{
+    if (! GPSTaskBase::configureHook())
+        return false;
+
+    topicSubscribe(&GPSTask::readInput, baseTopicName);
+    return true;
+}
+bool GPSTask::startHook()
+{
+    if (! GPSTaskBase::startHook())
+        return false;
+    utm_converter.setUtmZone(_utm_zone.value());
+    utm_converter.setUtmNorth(_utm_north.value());
+    utm_converter.setOrigin(_origin.value());
+    solutions.clear();
+    return true;
+}
+
+void GPSTask::updateHook()
+{
+    vector<gps_base::Solution> solutions;
+    { lock_guard<mutex> readGuard(readMutex);
+        solutions = move(this->solutions);
+    }
+
+    for (auto const& solution : solutions)
+    {
+        _gps_solution.write(solution);
+        base::samples::RigidBodyState rbs;
+        rbs.sourceFrame = _gps_frame.value();
+        rbs.targetFrame = _world_frame.value();
+        utm_converter.convertSolutionToRBS(solution, rbs);
+        rbs.time = solution.time;
+        _position_samples.write(rbs);
+    }
+    GPSTaskBase::updateHook();
+}
+void GPSTask::errorHook()
+{
+    GPSTaskBase::errorHook();
+}
+void GPSTask::stopHook()
+{
+    GPSTaskBase::stopHook();
+}
+void GPSTask::cleanupHook()
+{
+    GPSTaskBase::cleanupHook();
+}
+
+void GPSTask::setGazeboModel(ModelPtr model, sdf::ElementPtr sdfSensor)
+{
+    GPSTaskBase::setGazeboModel(model, sdfSensor);
+    sdf::ElementPtr gps = sdfSensor->GetElement("gps");
+
+    sdf::ElementPtr h_noise = gps
+        ->GetElement("position_sensing")
+        ->GetElement("horizontal")
+        ->GetElement("noise");
+    deviationHorizontal = 1;
+    if (h_noise->HasElement("stddev"))
+        deviationHorizontal = h_noise->Get<double>("stddev");
+
+    sdf::ElementPtr v_noise = gps
+        ->GetElement("position_sensing")
+        ->GetElement("vertical")
+        ->GetElement("noise");
+    deviationVertical = 1;
+    if (v_noise->HasElement("stddev"))
+        deviationVertical = v_noise->Get<double>("stddev");
+}
+
+void GPSTask::readInput( ConstGPSPtr & msg)
+{ lock_guard<mutex> readGuard(readMutex);
+    gps_base::Solution solution;
+    solution.time = getCurrentTime(msg->time());
+    solution.latitude = msg->latitude_deg();
+    solution.longitude = msg->longitude_deg();
+    solution.altitude = msg->altitude();
+    solution.positionType = gps_base::AUTONOMOUS;
+    solution.noOfSatellites = 5;
+    solution.geoidalSeparation = base::unknown<double>();
+    solution.ageOfDifferentialCorrections = 0;
+    solution.deviationAltitude = deviationVertical;
+    solution.deviationLatitude = deviationHorizontal;
+    solution.deviationLongitude = deviationHorizontal;
+    solutions.emplace_back(move(solution));
+}
+

--- a/tasks/GPSTask.hpp
+++ b/tasks/GPSTask.hpp
@@ -1,0 +1,122 @@
+/* Generated from orogen/lib/orogen/templates/tasks/Task.hpp */
+
+#ifndef ROCK_GAZEBO_GPSTASK_TASK_HPP
+#define ROCK_GAZEBO_GPSTASK_TASK_HPP
+
+#include "rock_gazebo/GPSTaskBase.hpp"
+#include <gps_base/BaseTypes.hpp>
+#include <gps_base/UTMConverter.hpp>
+
+#include <gazebo/msgs/gps.pb.h>
+
+namespace rock_gazebo{
+
+    /*! \class GPSTask
+     * \brief The task context provides and requires services. It uses an ExecutionEngine to perform its functions.
+     * Essential interfaces are operations, data flow ports and properties. These interfaces have been defined using the oroGen specification.
+     * In order to modify the interfaces you should (re)use oroGen and rely on the associated workflow.
+     * 
+     * \details
+     * The name of a TaskContext is primarily defined via:
+     \verbatim
+     deployment 'deployment_name'
+         task('custom_task_name','rock_gazebo::GPSTask')
+     end
+     \endverbatim
+     *  It can be dynamically adapted when the deployment is called with a prefix argument.
+     */
+    class GPSTask : public GPSTaskBase
+    {
+	friend class GPSTaskBase;
+
+    private:
+        gps_base::UTMConverter utm_converter;
+        double deviationHorizontal;
+        double deviationVertical;
+        void setGazeboModel(ModelPtr model, sdf::ElementPtr sdfSensor);
+
+        std::vector<gps_base::Solution> solutions;
+
+    protected:
+        void readInput(ConstGPSPtr &msg);
+
+    public:
+        /** TaskContext constructor for GPSTask
+         * \param name Name of the task. This name needs to be unique to make it identifiable via nameservices.
+         * \param initial_state The initial TaskState of the TaskContext. Default is Stopped state.
+         */
+        GPSTask(std::string const& name = "rock_gazebo::GPSTask");
+
+        /** TaskContext constructor for GPSTask
+         * \param name Name of the task. This name needs to be unique to make it identifiable for nameservices.
+         * \param engine The RTT Execution engine to be used for this task, which serialises the execution of all commands, programs, state machines and incoming events for a task.
+         * 
+         */
+        GPSTask(std::string const& name, RTT::ExecutionEngine* engine);
+
+        /** Default deconstructor of GPSTask
+         */
+	~GPSTask();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from PreOperational to Stopped. If it returns false, then the
+         * component will stay in PreOperational. Otherwise, it goes into
+         * Stopped.
+         *
+         * It is meaningful only if the #needs_configuration has been specified
+         * in the task context definition with (for example):
+         \verbatim
+         task_context "TaskName" do
+           needs_configuration
+           ...
+         end
+         \endverbatim
+         */
+        bool configureHook();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from Stopped to Running. If it returns false, then the component will
+         * stay in Stopped. Otherwise, it goes into Running and updateHook()
+         * will be called.
+         */
+        bool startHook();
+
+        /** This hook is called by Orocos when the component is in the Running
+         * state, at each activity step. Here, the activity gives the "ticks"
+         * when the hook should be called.
+         *
+         * The error(), exception() and fatal() calls, when called in this hook,
+         * allow to get into the associated RunTimeError, Exception and
+         * FatalError states.
+         *
+         * In the first case, updateHook() is still called, and recover() allows
+         * you to go back into the Running state.  In the second case, the
+         * errorHook() will be called instead of updateHook(). In Exception, the
+         * component is stopped and recover() needs to be called before starting
+         * it again. Finally, FatalError cannot be recovered.
+         */
+        void updateHook();
+
+        /** This hook is called by Orocos when the component is in the
+         * RunTimeError state, at each activity step. See the discussion in
+         * updateHook() about triggering options.
+         *
+         * Call recover() to go back in the Runtime state.
+         */
+        void errorHook();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from Running to Stopped after stop() has been called.
+         */
+        void stopHook();
+
+        /** This hook is called by Orocos when the state machine transitions
+         * from Stopped to PreOperational, requiring the call to configureHook()
+         * before calling start() again.
+         */
+        void cleanupHook();
+    };
+}
+
+#endif
+

--- a/tasks/ImuTask.cpp
+++ b/tasks/ImuTask.cpp
@@ -31,6 +31,7 @@ bool ImuTask::configureHook()
     if (! ImuTaskBase::configureHook())
         return false;
 
+    topicSubscribe(&ImuTask::readInput, baseTopicName + "/imu");
     return true;
 }
 bool ImuTask::startHook()
@@ -39,7 +40,6 @@ bool ImuTask::startHook()
         return false;
 
     samples.clear();
-    topicSubscribe(&ImuTask::readInput, baseTopicName + "/imu");
     return true;
 }
 void ImuTask::updateHook()

--- a/tasks/ImuTask.cpp
+++ b/tasks/ImuTask.cpp
@@ -31,19 +31,13 @@ bool ImuTask::configureHook()
     if (! ImuTaskBase::configureHook())
         return false;
 
-    // Initialize communication node and subscribe to gazebo topic
-    node = transport::NodePtr( new transport::Node() );
-    node->Init();
-
-    imu_subscriber = node->Subscribe("~/" + topicName, &ImuTask::readInput, this);
-    gzmsg << "ImuTask: subscribing to gazebo topic ~/" + topicName << endl;
-
     return true;
 }
 bool ImuTask::startHook()
 {
     if (! ImuTaskBase::startHook())
         return false;
+    topicSubscribe(&ImuTask::readInput, baseTopicName + "/imu");
     return true;
 }
 void ImuTask::updateHook()
@@ -71,20 +65,6 @@ void ImuTask::stopHook()
 void ImuTask::cleanupHook()
 {
     ImuTaskBase::cleanupHook();
-    node->Fini();
-}
-
-void ImuTask::setGazeboModel( ModelPtr model, string sensorName, string topicName )
-{
-    string taskName = "gazebo:" + model->GetWorld()->GetName() + ":" + model->GetName() + ":" + sensorName;
-    if(!provides())
-        throw std::runtime_error("ImuTask::provides returned NULL");
-    provides()->setName(taskName);
-    _name.set(taskName);
-    BaseTask::setGazeboWorld( model->GetWorld() );
-
-    // Set topic name to communicate with Gazebo
-    this->topicName = topicName;
 }
 
 void ImuTask::readInput( ConstIMUPtr & imuMsg)

--- a/tasks/ImuTask.hpp
+++ b/tasks/ImuTask.hpp
@@ -3,8 +3,6 @@
 #ifndef ROCK_GAZEBO_IMUTASK_TASK_HPP
 #define ROCK_GAZEBO_IMUTASK_TASK_HPP
 
-#include <gazebo/physics/physics.hh>
-#include <gazebo/transport/transport.hh>
 #include <gazebo/msgs/imu.pb.h>
 #include <base/samples/IMUSensors.hpp>
 
@@ -109,14 +107,9 @@ namespace rock_gazebo{
          */
         void cleanupHook();
 
-        typedef gazebo::physics::ModelPtr ModelPtr;
-        void setGazeboModel( ModelPtr model, std::string sensorName, std::string topicName);
         void readInput( ConstIMUPtr &imuMsg);
 
     private:
-        std::string topicName;
-        gazebo::transport::NodePtr node;
-        gazebo::transport::SubscriberPtr imu_subscriber;
         base::samples::RigidBodyState imu_reading;
         base::samples::IMUSensors imu_samples;
     };

--- a/tasks/ImuTask.hpp
+++ b/tasks/ImuTask.hpp
@@ -3,10 +3,14 @@
 #ifndef ROCK_GAZEBO_IMUTASK_TASK_HPP
 #define ROCK_GAZEBO_IMUTASK_TASK_HPP
 
-#include <gazebo/msgs/imu.pb.h>
-#include <base/samples/IMUSensors.hpp>
-
 #include "rock_gazebo/ImuTaskBase.hpp"
+
+#include <list>
+#include <utility>
+
+#include <base/samples/IMUSensors.hpp>
+#include <base/samples/RigidBodyState.hpp>
+#include <gazebo/msgs/imu.pb.h>
 
 namespace rock_gazebo{
 
@@ -110,8 +114,8 @@ namespace rock_gazebo{
         void readInput( ConstIMUPtr &imuMsg);
 
     private:
-        base::samples::RigidBodyState imu_reading;
-        base::samples::IMUSensors imu_samples;
+        typedef std::vector<std::pair<base::samples::RigidBodyState, base::samples::IMUSensors>> Samples;
+        Samples samples;
     };
 }
 

--- a/tasks/LaserScanTask.cpp
+++ b/tasks/LaserScanTask.cpp
@@ -28,12 +28,7 @@ bool LaserScanTask::configureHook()
     if (! LaserScanTaskBase::configureHook())
         return false;
 
-    // Initialize communication node and subscribe to gazebo topic
-    node = transport::NodePtr( new transport::Node() );
-    node->Init();
-    laserScanSubscriber = node->Subscribe("~/" + topicName, &LaserScanTask::readInput, this);
-    gzmsg << "LaserScanTask: subscribing to gazebo topic ~/" + topicName << endl;
-
+    topicSubscribe(&LaserScanTask::readInput, baseTopicName + "/scan");
     return true;
 }
 
@@ -66,19 +61,6 @@ void LaserScanTask::cleanupHook()
 {
     LaserScanTaskBase::cleanupHook();
 
-    node->Fini();
-}
-
-void LaserScanTask::setGazeboModel( ModelPtr model, string sensorName, string topicName )
-{
-    string taskName = "gazebo:" + model->GetWorld()->GetName() + ":" + model->GetName() + ":" + sensorName;
-    provides()->setName(taskName);
-    _name.set(taskName);
-
-    BaseTask::setGazeboWorld( model->GetWorld() );
-
-    // Set topic name to communicate with Gazebo
-    this->topicName = topicName;
 }
 
 

--- a/tasks/LaserScanTask.hpp
+++ b/tasks/LaserScanTask.hpp
@@ -27,8 +27,7 @@ namespace rock_gazebo{
 
     private:
         void readInput( ConstLaserScanStampedPtr &laserScanMSG );
-
-        base::samples::LaserScan laserScanCMD;
+        std::vector<base::samples::LaserScan> scans;
     };
 }
 

--- a/tasks/LaserScanTask.hpp
+++ b/tasks/LaserScanTask.hpp
@@ -24,15 +24,9 @@ namespace rock_gazebo{
         void stopHook();
         void cleanupHook();
 
-        typedef gazebo::physics::ModelPtr ModelPtr;
-
-        void setGazeboModel( ModelPtr model, std::string sensorName, std::string topicName);
-        void readInput( ConstLaserScanStampedPtr &laserScanMSG );
 
     private:
-        std::string topicName;
-        gazebo::transport::NodePtr node;
-        gazebo::transport::SubscriberPtr laserScanSubscriber;
+        void readInput( ConstLaserScanStampedPtr &laserScanMSG );
 
         base::samples::LaserScan laserScanCMD;
     };

--- a/tasks/SensorTask.cpp
+++ b/tasks/SensorTask.cpp
@@ -1,0 +1,89 @@
+/* Generated from orogen/lib/orogen/templates/tasks/Task.cpp */
+
+#include "SensorTask.hpp"
+#include <gazebo/transport/transport.hh>
+#include <gazebo/sensors/sensors.hh>
+#include <sdf/sdf.hh>
+
+using namespace rock_gazebo;
+using namespace std;
+
+SensorTask::SensorTask(std::string const& name)
+    : SensorTaskBase(name)
+{
+}
+
+SensorTask::SensorTask(std::string const& name, RTT::ExecutionEngine* engine)
+    : SensorTaskBase(name, engine)
+{
+}
+
+SensorTask::~SensorTask()
+{
+}
+
+
+
+/// The following lines are template definitions for the various state machine
+// hooks defined by Orocos::RTT. See SensorTask.hpp for more detailed
+// documentation about them.
+
+bool SensorTask::configureHook()
+{
+    if (! SensorTaskBase::configureHook())
+        return false;
+
+    // Initialize communication node and subscribe to gazebo topic
+    node = gazebo::transport::NodePtr( new gazebo::transport::Node() );
+    node->Init();
+
+    return true;
+}
+bool SensorTask::startHook()
+{
+    if (! SensorTaskBase::startHook())
+        return false;
+    gazebo::sensors::SensorPtr sensor = gazebo::sensors::get_sensor(sensorFullName);
+    sensor->SetActive(true);
+    return true;
+}
+void SensorTask::updateHook()
+{
+    SensorTaskBase::updateHook();
+}
+void SensorTask::errorHook()
+{
+    SensorTaskBase::errorHook();
+}
+void SensorTask::stopHook()
+{
+    gazebo::sensors::SensorPtr sensor = gazebo::sensors::get_sensor(sensorFullName);
+    sensor->SetActive(false);
+    SensorTaskBase::stopHook();
+}
+void SensorTask::cleanupHook()
+{
+    node->Fini();
+    SensorTaskBase::cleanupHook();
+}
+void SensorTask::setGazeboModel(ModelPtr model, sdf::ElementPtr sdfSensor)
+{
+    sdf::ElementPtr sdfLink = sdfSensor->GetParent();
+    this->gazeboModel = model;
+    this->sdfSensor = sdfSensor;
+
+    sensorFullName =
+        model->GetWorld()->GetName() + "::" +
+        model->GetScopedName() + "::" +
+        sdfLink->Get<string>("name") + "::" +
+        sdfSensor->Get<string>("name");
+    baseTopicName = "~/" + model->GetName() + "/" + sdfLink->Get<string>("name") + "/" + sdfSensor->Get<string>("name");
+
+    string taskName = "gazebo:" + model->GetWorld()->GetName() + ":" + model->GetName() + ":" + sdfSensor->Get<string>("name");
+    if(!provides())
+        throw std::runtime_error("GPSTask::provides returned NULL");
+    provides()->setName(taskName);
+    _name.set(taskName);
+    BaseTask::setGazeboWorld( model->GetWorld() );
+}
+

--- a/tasks/SensorTask.hpp
+++ b/tasks/SensorTask.hpp
@@ -1,39 +1,51 @@
 /* Generated from orogen/lib/orogen/templates/tasks/Task.hpp */
 
-#ifndef ROCK_GAZEBO_CAMERATASK_TASK_HPP
-#define ROCK_GAZEBO_CAMERATASK_TASK_HPP
+#ifndef ROCK_GAZEBO_SENSORTASK_TASK_HPP
+#define ROCK_GAZEBO_SENSORTASK_TASK_HPP
 
-#include <gazebo/physics/physics.hh>
-#include <gazebo/transport/transport.hh>
-#include <gazebo/msgs/camerasensor.pb.h>
-
-#include "rock_gazebo/CameraTaskBase.hpp"
+#include "rock_gazebo/SensorTaskBase.hpp"
+#include <gazebo/transport/Node.hh>
 
 namespace rock_gazebo{
 
-    class CameraTask : public CameraTaskBase
+    /*! \class SensorTask
+     * \brief The task context provides and requires services. It uses an ExecutionEngine to perform its functions.
+     * Essential interfaces are operations, data flow ports and properties. These interfaces have been defined using the oroGen specification.
+     * In order to modify the interfaces you should (re)use oroGen and rely on the associated workflow.
+     * 
+     * \details
+     * The name of a TaskContext is primarily defined via:
+     \verbatim
+     deployment 'deployment_name'
+         task('custom_task_name','rock_gazebo::SensorTask')
+     end
+     \endverbatim
+     *  It can be dynamically adapted when the deployment is called with a prefix argument.
+     */
+    class SensorTask : public SensorTaskBase
     {
-	friend class CameraTaskBase;
+	friend class SensorTaskBase;
     protected:
 
 
+
     public:
-        /** TaskContext constructor for CameraTask
+        /** TaskContext constructor for SensorTask
          * \param name Name of the task. This name needs to be unique to make it identifiable via nameservices.
          * \param initial_state The initial TaskState of the TaskContext. Default is Stopped state.
          */
-        CameraTask(std::string const& name = "rock_gazebo::CameraTask");
+        SensorTask(std::string const& name = "rock_gazebo::SensorTask");
 
-        /** TaskContext constructor for CameraTask
+        /** TaskContext constructor for SensorTask
          * \param name Name of the task. This name needs to be unique to make it identifiable for nameservices.
          * \param engine The RTT Execution engine to be used for this task, which serialises the execution of all commands, programs, state machines and incoming events for a task.
          * 
          */
-        CameraTask(std::string const& name, RTT::ExecutionEngine* engine);
+        SensorTask(std::string const& name, RTT::ExecutionEngine* engine);
 
-        /** Default deconstructor of CameraTask
+        /** Default deconstructor of SensorTask
          */
-	~CameraTask();
+	~SensorTask();
 
         /** This hook is called by Orocos when the state machine transitions
          * from PreOperational to Stopped. If it returns false, then the
@@ -93,11 +105,24 @@ namespace rock_gazebo{
          */
         void cleanupHook();
 
+        typedef gazebo::physics::ModelPtr ModelPtr;
+        virtual void setGazeboModel(ModelPtr model, sdf::ElementPtr sdfSensor);
 
-    private:
-        void readInput( ConstImageStampedPtr &imageMsg);
-        bool bnew_data;
-        RTT::extras::ReadOnlyPointer<base::samples::frame::Frame> output_frame;	
+    protected:
+        template<typename M, typename T>
+        void topicSubscribe(void(T::*_fp)(const boost::shared_ptr< M const > &), std::string topicName)
+        {
+            subscriber = node->Subscribe(topicName, _fp, static_cast<T*>(this));
+            gzmsg << getName() << ": subscribed to gazebo topic ~/" + topicName << std::endl;
+        }
+
+        ModelPtr gazeboModel;
+        sdf::ElementPtr sdfSensor;
+        gazebo::transport::SubscriberPtr subscriber;
+        gazebo::transport::NodePtr node;
+        std::mutex readMutex;
+        std::string sensorFullName;
+        std::string baseTopicName;
     };
 }
 


### PR DESCRIPTION
While integrating the GPS, the [sensor support got refactored in simulation/rock_gazebo](https://github.com/Brazilian-Institute-of-Robotics/simulation-rock_gazebo/pull/34). This is the orogen-side part of it, adding a GPSTask and refactoring the sensor setup.

Note that it fixes the issue that all sensors needed to have an `always_on` tag by starting/stopping sensors explicitely in the task start/stop hooks.