### PR TITLE
allow setting independent covariances for all exported links

### DIFF
--- a/rock_gazeboTypes.hpp
+++ b/rock_gazeboTypes.hpp
@@ -2,7 +2,9 @@
 #define rock_gazebo_TYPES_HPP
 
 #include <iostream>
-#include "base/Time.hpp"
+#include <base/Time.hpp>
+#include <base/Eigen.hpp>
+#include <base/Float.hpp>
 
 namespace rock_gazebo
 {
@@ -19,6 +21,17 @@ namespace rock_gazebo
         std::string target_link;
         // The period of update the output port
         base::Time port_period;
+        // The position covariance
+        base::Matrix3d cov_position;
+        // The orientation covariance
+        base::Matrix3d cov_orientation;
+        // The velocity covariance
+        base::Matrix3d cov_velocity;
+
+        LinkExport()
+            : cov_position(base::Matrix3d::Ones() * base::unset<double>())
+            , cov_orientation(base::Matrix3d::Ones() * base::unset<double>())
+            , cov_velocity(base::Matrix3d::Ones() * base::unset<double>()) {}
     };
 }
 

--- a/tasks/ModelTask.cpp
+++ b/tasks/ModelTask.cpp
@@ -73,7 +73,7 @@ void ModelTask::setupLinks()
     for(vector<LinkExport>::iterator it = export_conf.begin();
             it != export_conf.end(); ++it)
     {
-        ExportedLink exported_link;
+        ExportedLink exported_link(*it);
 
         exported_link.source_link =
             checkExportedLinkElements("source_link", it->source_link, _world_frame.get());
@@ -264,13 +264,13 @@ void ModelTask::updateLinks(base::Time const& time)
         rbs.targetFrame = it->second.target_frame;
         rbs.position = base::Vector3d(
             source2target.pos.x,source2target.pos.y,source2target.pos.z);
-        rbs.cov_position = _cov_position;
+        rbs.cov_position = it->second.cov_position;
         rbs.orientation = base::Quaterniond(
             source2target.rot.w,source2target.rot.x,source2target.rot.y,source2target.rot.z );
-        rbs.cov_orientation = _cov_orientation;
+        rbs.cov_orientation = it->second.cov_orientation;
         rbs.velocity = base::Vector3d(
             sourceInTarget_linear_vel.x,sourceInTarget_linear_vel.y,sourceInTarget_linear_vel.z);
-        rbs.cov_velocity = _cov_velocity;
+        rbs.cov_velocity = it->second.cov_velocity;
         rbs.angular_velocity = base::Vector3d(
             source_angular_vel.x,source_angular_vel.y,source_angular_vel.z);
         rbs.time = time;

--- a/tasks/ModelTask.hpp
+++ b/tasks/ModelTask.hpp
@@ -43,6 +43,9 @@ namespace rock_gazebo {
 
                 ExportedLink()
                     : port(NULL) { }
+                ExportedLink(LinkExport const& src)
+                    : LinkExport(src)
+                    , port(NULL) { }
             };
             typedef std::map<std::string, ExportedLink> ExportedLinks;
             ExportedLinks exported_links;


### PR DESCRIPTION
Note that this will break existing installs, as formerly the covariances were set task-wide from the task's property. There's no special "no value" which would allow us to both keep that behaviour *and* allow setting a covariance to NaNs.

Integration in Syskit and tests in https://github.com/Brazilian-Institute-of-Robotics/simulation-rock_gazebo/pull/35
