### PR TITLE
workaround the lack of mercator projection in Gazebo's spherical coordinate handling

### DIFF
--- a/rock_gazebo.orogen
+++ b/rock_gazebo.orogen
@@ -127,6 +127,13 @@ task_context "GPSTask" do
     # The name of the reference frame for the position samples
     property('nwu_frame', '/std/string', 'nwu')
 
+    # Use a proper transverse mercator projection or Gazebo's
+    # internal SphericalCoordinate conversion class
+    #
+    # If you intend to compare true positions provided by ModelTask to things
+    # that use the GPS, this must be false
+    property('use_proper_utm_conversion', "bool", false)
+
     # The raw GPS position
     output_port "gps_solution", "gps_base/Solution"
 
@@ -136,13 +143,22 @@ task_context "GPSTask" do
     # Computed position in m, in the NWU coordinate frame
     output_port 'position_samples', '/base/samples/RigidBodyState'
 
-    # UTM zone for conversion of WGS84 to UTM
+    # UTM zone for conversion of WGS84 to UTM if use_proper_utm_conversion is
+    # true
     property("utm_zone", "int", 32)
 
-    # UTM north for conversion of WGS84 to UTM
+    # UTM north for conversion of WGS84 to UTM if use_proper_utm_conversion is
+    # true
     property("utm_north", "bool", true)
 
-    # Origin in UTM coordinates, that is used for position readings.
+    # Origin in UTM coordinates, that is used for position readings if
+    # use_proper_utm_conversion is true
     property("nwu_origin", "/base/Position")
+
+    # Latitude of the origin if use_proper_utm_conversion is false
+    property('latitude_origin', "/base/Angle")
+
+    # Longitude of the origin if use_proper_utm_conversion is false
+    property('longitude_origin', "/base/Angle")
 end
 

--- a/tasks/GPSTask.cpp
+++ b/tasks/GPSTask.cpp
@@ -5,6 +5,7 @@
 
 using namespace std;
 using namespace rock_gazebo;
+using gazebo::common::SphericalCoordinates;
 
 GPSTask::GPSTask(std::string const& name)
     : GPSTaskBase(name)
@@ -44,9 +45,21 @@ bool GPSTask::startHook()
 {
     if (! GPSTaskBase::startHook())
         return false;
-    utm_converter.setUTMZone(_utm_zone.value());
-    utm_converter.setUTMNorth(_utm_north.value());
-    utm_converter.setNWUOrigin(_nwu_origin.value());
+
+    if (_use_proper_utm_conversion.get())
+    {
+        utm_converter.setUTMZone(_utm_zone.value());
+        utm_converter.setUTMNorth(_utm_north.value());
+        utm_converter.setNWUOrigin(_nwu_origin.value());
+    }
+    else
+    {
+        utm_converter.setNWUOrigin(Eigen::Vector3d::Zero());
+        gazebo_spherical.SetLatitudeReference(
+                ignition::math::Angle(_latitude_origin.value().getRad()));
+        gazebo_spherical.SetLongitudeReference(
+                ignition::math::Angle(_longitude_origin.value().getRad()));
+    }
     solutions.clear();
     return true;
 }
@@ -61,13 +74,35 @@ void GPSTask::updateHook()
     for (auto const& solution : solutions)
     {
         _gps_solution.write(solution);
+        base::samples::RigidBodyState utm, position;
 
-        base::samples::RigidBodyState utm = utm_converter.convertToUTM(solution);
+        if (_use_proper_utm_conversion.get())
+        {
+            utm = utm_converter.convertToUTM(solution);
+            position = utm_converter.convertToNWU(utm);
+        }
+        else
+        {
+            ignition::math::Vector3d local = gazebo_spherical.LocalFromSpherical(
+                    ignition::math::Vector3d(solution.latitude, solution.longitude, solution.altitude));
+
+            utm.position = Eigen::Vector3d(local.X(), local.Y(), local.Z());
+            utm.cov_position = 1.0 * base::Matrix3d::Identity();
+            utm.cov_position(0, 0) = solution.deviationLongitude * solution.deviationLongitude;
+            utm.cov_position(1, 1) = solution.deviationLatitude * solution.deviationLatitude;
+            utm.cov_position(2, 2) = solution.deviationAltitude * solution.deviationAltitude;
+            
+            position.position = Eigen::Vector3d(local.Y(), -local.X(), local.Z());
+            position.cov_position = utm.cov_position;
+            std::swap(position.cov_position(0, 0), position.cov_position(1, 1));
+        }
+
+        utm.time = solution.time;
         utm.sourceFrame = _gps_frame.value();
         utm.targetFrame = _utm_frame.value();
         _utm_samples.write(utm);
 
-        base::samples::RigidBodyState position = utm_converter.convertToNWU(utm);
+        position.time = solution.time;
         position.sourceFrame = _gps_frame.value();
         position.targetFrame = _nwu_frame.value();
         _position_samples.write(position);

--- a/tasks/GPSTask.hpp
+++ b/tasks/GPSTask.hpp
@@ -8,6 +8,7 @@
 #include <gps_base/UTMConverter.hpp>
 
 #include <gazebo/msgs/gps.pb.h>
+#include <gazebo/common/SphericalCoordinates.hh>
 
 namespace rock_gazebo{
 
@@ -36,6 +37,7 @@ namespace rock_gazebo{
         void setGazeboModel(ModelPtr model, sdf::ElementPtr sdfSensor);
 
         std::vector<gps_base::Solution> solutions;
+        gazebo::common::SphericalCoordinates gazebo_spherical;
 
     protected:
         void readInput(ConstGPSPtr &msg);


### PR DESCRIPTION
The GPSTask component now optionally allows to use Gazebo's own
SphericalCoordinates class to handle the latlon-to-cartesian conversion,
ensuring that the position matches the vehicle "true" position.

Long-run, we should propose a mercator projection to Gazebo. The
current method basically assumes that a vehicle that stays at Z=0
starts flying after a while ...

Tests implemented by https://github.com/Brazilian-Institute-of-Robotics/simulation-rock_gazebo/pull/37